### PR TITLE
Prelint creates public/ if not exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,5 @@ typings/
 # Tern
 .tern-port
 
-public
+public/*
+!public/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,4 @@ typings/
 # Tern
 .tern-port
 
-public/*
-!public/.gitkeep
+public

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prebuild": "rm -rf public; mkdir public; cp -r src/assets/* public/;",
     "build": "rollup -c config/prod.js",
     "postbuild": "react-snap",
-    "prelint": "if test ! -d public; then mkdir public; fi; cp -r src/assets/* public/;",
+    "prelint": "cp -r src/assets/* public/",
     "lint": "standard --verbose --parser babel-eslint | snazzy",
     "test": "standard --verbose --parser babel-eslint | snazzy",
     "docs": "cd src/ && docco {**,.,**/**,**/**/**}/*.js --output ../docs --layout parallel",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prebuild": "rm -rf public; mkdir public; cp -r src/assets/* public/;",
     "build": "rollup -c config/prod.js",
     "postbuild": "react-snap",
-    "prelint": "cp -r src/assets/* public/",
+    "prelint": "if test ! -d public; then mkdir public; fi; cp -r src/assets/* public/;",
     "lint": "standard --verbose --parser babel-eslint | snazzy",
     "test": "standard --verbose --parser babel-eslint | snazzy",
     "docs": "cd src/ && docco {**,.,**/**,**/**/**}/*.js --output ../docs --layout parallel",


### PR DESCRIPTION
`npm start` fails on a freshly cloned copy without a public/ directory.
The error message that npm and cp generate in this case doesn't make it super obvious what the problem really is.

Let me know if it would be better to go with the same style script as prebuild (`"rm -rf public; mkdir public; cp -r src/assets/* public/;"`) rather than if & test.