### PR TITLE
Create public/ directory for prelint if nonexistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prebuild": "rm -rf public; mkdir public; cp -r src/assets/* public/;",
     "build": "rollup -c config/prod.js",
     "postbuild": "react-snap",
-    "prelint": "cp -r src/assets/* public/",
+    "prelint": "mkdir -p public; cp -r src/assets/* public/",
     "lint": "standard --verbose --parser babel-eslint | snazzy",
     "test": "standard --verbose --parser babel-eslint | snazzy",
     "docs": "cd src/ && docco {**,.,**/**,**/**/**}/*.js --output ../docs --layout parallel",


### PR DESCRIPTION
Otherwise prelint fails on first `npm start` for a freshly cloned and installed project.

Alternately, we could change line 8 from
```
"preinstall": "if test -z \"$NODE_ENV\"; then rm .git/hooks/pre-commit; cp pre-commit.sh .git/hooks/pre-commit; else rm -rf public; mkdir public; fi",
```
to
```
"preinstall": "if test -z \"$NODE_ENV\"; then rm .git/hooks/pre-commit; cp pre-commit.sh .git/hooks/pre-commit; fi; rm -rf public; mkdir public;",
```