### PR TITLE
Replace connect() with useMappedState()

### DIFF
--- a/src/elements/global-header/global-header.js
+++ b/src/elements/global-header/global-header.js
@@ -2,12 +2,17 @@ import Avatar from '@app-elements/avatar'
 import { Link } from '@app-elements/router'
 import { useMappedState } from '@app-elements/use-mapped-state'
 
-import store from '/store'
-
 import './global-header.less'
 
-const Base = ({ clicks, increment }) =>
-  <header class='global-header'>
+function GlobalHeader () {
+  const clicks = useMappedState(
+    this.context.store,
+    ({ clicks }) => clicks
+  )
+
+  const increment = () => this.context.store.setState({ clicks: clicks + 1 })
+
+  return <header class='global-header'>
     <div className='container'>
 
       <div className='logo'>
@@ -28,11 +33,6 @@ const Base = ({ clicks, increment }) =>
 
     </div>
   </header>
-
-export const GlobalHeader = () => {
-  const clicks = useMappedState(store, ({ clicks }) => clicks)
-
-  const increment = () => store.setState({ clicks: clicks + 1 })
-
-  return Base({ clicks, increment })
 }
+
+export { GlobalHeader }

--- a/src/elements/global-header/global-header.js
+++ b/src/elements/global-header/global-header.js
@@ -1,18 +1,13 @@
 import Avatar from '@app-elements/avatar'
-import connect from '@app-elements/connect'
 import { Link } from '@app-elements/router'
+import { useMappedState } from '@app-elements/use-mapped-state'
+
+import store from '/store'
 
 import './global-header.less'
 
-export const GlobalHeader = connect({
-  name: 'GlobalHeader',
-  withActions: {
-    increment: ({ clicks }) => ({ clicks: (clicks || 0) + 1 })
-  },
-  withState: ({ clicks }) => ({ clicks })
-})(({ clicks, increment }) => (
+const Base = ({ clicks, increment }) =>
   <header class='global-header'>
-
     <div className='container'>
 
       <div className='logo'>
@@ -22,18 +17,22 @@ export const GlobalHeader = connect({
           <li><Link name='users' activeClass='active-link'>Dashboard App</Link></li>
           <li><button onClick={increment}>+</button></li>
         </ul>
-
       </div>
 
       <div className='user-actions'>
-
         <Avatar
           src='/images/_temp/avatar.png'
           fullName='John Smith'
-
         />
-
       </div>
+
     </div>
   </header>
-))
+
+export const GlobalHeader = () => {
+  const clicks = useMappedState(store, ({ clicks }) => clicks)
+
+  const increment = () => store.setState({ clicks: clicks + 1 })
+
+  return Base({ clicks, increment })
+}

--- a/src/elements/not-found.js
+++ b/src/elements/not-found.js
@@ -1,15 +1,16 @@
-import connect from '@app-elements/connect'
+import { useMappedState } from '@app-elements/use-mapped-state'
+
+import store from '/store'
 
 const Base = () =>
   <div className='container pt-10'>
     Not Found :(
   </div>
 
-const NotFound = connect({
-  name: 'NotFound',
-  withState: ({ currentRoute }) => ({ currentRoute })
-})(({ currentRoute }) =>
-  !currentRoute ? Base() : null
-)
+const NotFound = () => {
+  const currentRoute = useMappedState(store, ({ currentRoute }) => currentRoute)
+
+  return !currentRoute ? Base() : null
+}
 
 export default NotFound

--- a/src/elements/not-found.js
+++ b/src/elements/not-found.js
@@ -1,16 +1,16 @@
 import { useMappedState } from '@app-elements/use-mapped-state'
 
-import store from '/store'
+function NotFound () {
+  const currentRoute = useMappedState(
+    this.context.store,
+    ({ currentRoute }) => currentRoute
+  )
 
-const Base = () =>
-  <div className='container pt-10'>
-    Not Found :(
-  </div>
-
-const NotFound = () => {
-  const currentRoute = useMappedState(store, ({ currentRoute }) => currentRoute)
-
-  return !currentRoute ? Base() : null
+  if (!currentRoute) {
+    return <div className='container pt-10'>
+      Not Found :(
+    </div>
+  }
 }
 
 export default NotFound


### PR DESCRIPTION
As `connect()` is deprecated, we no longer need examples of its use. Updated a couple of components to use `useMappedState()` instead.