### PR TITLE
Use https for mocky endpoints

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -20,10 +20,10 @@ export default [
     namespace: 'api',
     url: '',
     routes: {
-      login: 'http://www.mocky.io/v2/5d28e8362c000068003edca8',
-      signup: 'http://www.mocky.io/v2/5d28efd02c0000cd2f3edcc9',
-      forgotPassword: 'http://www.mocky.io/v2/5d28e8362c000068003edca8',
-      resetPassword: 'http://www.mocky.io/v2/5e98de313500004d00c48670',
+      login: 'https://www.mocky.io/v2/5d28e8362c000068003edca8',
+      signup: 'https://www.mocky.io/v2/5d28efd02c0000cd2f3edcc9',
+      forgotPassword: 'https://www.mocky.io/v2/5d28e8362c000068003edca8',
+      resetPassword: 'https://www.mocky.io/v2/5e98de313500004d00c48670',
       users: 'https://jsonplaceholder.typicode.com/users',
       user: 'https://jsonplaceholder.typicode.com/users/:id'
     }


### PR DESCRIPTION
Was causing mixed content error for deployed instances (eg https://pwa-starter.netlify.app/login)